### PR TITLE
Save photo analysis records

### DIFF
--- a/src/app/api/analyze/route.ts
+++ b/src/app/api/analyze/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GoogleGenerativeAI } from "@google/generative-ai";
+import type { Prisma } from "@prisma/client";
 import { getCurrentUser, toSafeUser } from "@/lib/auth";
-import { decrementUserCredit } from "@/lib/db";
+import { decrementUserCreditAndCreateAnalysis } from "@/lib/db";
 
 // Define proper types for additionalInfo
 interface AdditionalInfo {
@@ -16,6 +17,47 @@ interface AdditionalInfo {
   specialNotes?: string;
   weight?: string;
 }
+
+type AnalysisResultPayload = Record<string, unknown>;
+
+const dataUrlPattern = /^data:(image\/[a-zA-Z0-9.+-]+);base64,/;
+
+const toJsonObject = (payload: AnalysisResultPayload): Prisma.InputJsonObject =>
+  JSON.parse(JSON.stringify(payload)) as Prisma.InputJsonObject;
+
+const getImagePayload = (image: string, imageIndex: number) => {
+  const mimeType = image.match(dataUrlPattern)?.[1] ?? "image/jpeg";
+  const base64Data = image.replace(dataUrlPattern, "");
+
+  return {
+    imageIndex,
+    mimeType,
+    dataUrl: image,
+    sizeBytes: Math.ceil((base64Data.length * 3) / 4),
+  };
+};
+
+const createAnalysisRecordPayload = ({
+  images,
+  additionalInfo,
+  result,
+}: {
+  images: string[];
+  additionalInfo?: AdditionalInfo;
+  result: AnalysisResultPayload;
+}) =>
+  toJsonObject({
+    source: "photo_analysis",
+    version: 1,
+    savedAt: new Date().toISOString(),
+    selectedInputs: additionalInfo ?? {},
+    photos: images.map((image, index) => getImagePayload(image, index + 1)),
+    result,
+    metadata: {
+      analysisType: result.analysisType,
+      totalImages: images.length,
+    },
+  });
 
 const createCreditErrorResponse = (
   error: "AUTH_REQUIRED" | "NO_CREDITS",
@@ -59,12 +101,22 @@ const getUserReadyForAnalysis = async () => {
   return { user, response: null };
 };
 
-const consumeAnalysisCredit = async (userId: string) => {
-  const updatedUser = await decrementUserCredit(userId);
+const saveAnalysisAndConsumeCredit = async ({
+  userId,
+  payload,
+}: {
+  userId: string;
+  payload: Prisma.InputJsonObject;
+}) => {
+  const savedAnalysis = await decrementUserCreditAndCreateAnalysis(
+    userId,
+    payload,
+  );
 
-  if (!updatedUser) {
+  if (!savedAnalysis) {
     return {
       user: null,
+      analysisId: null,
       response: createCreditErrorResponse(
         "NO_CREDITS",
         "Kredi hakkınız kalmadı",
@@ -73,7 +125,11 @@ const consumeAnalysisCredit = async (userId: string) => {
     };
   }
 
-  return { user: toSafeUser(updatedUser), response: null };
+  return {
+    user: toSafeUser(savedAnalysis.user),
+    analysisId: savedAnalysis.analysis.id,
+    response: null,
+  };
 };
 
 // Initialize Gemini API
@@ -619,7 +675,9 @@ const analyzeMultipleImages = async ({
   additionalInfo?: AdditionalInfo;
   userId: string;
 }) => {
-  console.log(`🔬 Aynı hayvana ait ${images.length} fotoğraf analiz ediliyor...`);
+  console.log(
+    `🔬 Aynı hayvana ait ${images.length} fotoğraf analiz ediliyor...`,
+  );
 
   try {
     // Basitleştirilmiş yaklaşım: Sadece ilk fotoğrafı analiz et, ama çoklu fotoğraf olduğunu belirt
@@ -663,8 +721,6 @@ const analyzeMultipleImages = async ({
     }
 
     const detailedAnalysis = calculateDetailedAnalysis(basicAnalysis);
-    const creditConsumption = await consumeAnalysisCredit(userId);
-    if (creditConsumption.response) return creditConsumption.response;
 
     const multipleImageResult = {
       success: true,
@@ -692,13 +748,28 @@ const analyzeMultipleImages = async ({
       recommendations: detailedAnalysis.recommendations,
       analysisDate: new Date().toISOString(),
       analysisNote: `Aynı hayvana ait ${images.length} farklı açıdan çekilmiş fotoğraf analiz edildi - yüksek güvenilirlik`,
+    };
+
+    const creditConsumption = await saveAnalysisAndConsumeCredit({
+      userId,
+      payload: createAnalysisRecordPayload({
+        images,
+        additionalInfo,
+        result: multipleImageResult,
+      }),
+    });
+    if (creditConsumption.response) return creditConsumption.response;
+
+    const responseBody = {
+      ...multipleImageResult,
+      savedAnalysisId: creditConsumption.analysisId,
       user: creditConsumption.user,
     };
 
     console.log(
       `✅ Aynı hayvana ait ${images.length} fotoğraf başarıyla analiz edildi`,
     );
-    return NextResponse.json(multipleImageResult);
+    return NextResponse.json(responseBody);
   } catch (error) {
     console.error("❌ Çoklu resim analiz hatası:", error);
 
@@ -707,7 +778,8 @@ const analyzeMultipleImages = async ({
       {
         success: false,
         error: "ANALYSIS_ERROR",
-        message: "Çoklu fotoğraf analizi başarısız oldu - lütfen tekrar deneyin",
+        message:
+          "Çoklu fotoğraf analizi başarısız oldu - lütfen tekrar deneyin",
         analysisType: "multiple_same_animal",
         totalImages: images.length,
         confidence: 0,
@@ -784,9 +856,6 @@ export async function POST(request: NextRequest) {
 
     const detailedAnalysis = calculateDetailedAnalysis(basicAnalysis);
 
-    const creditConsumption = await consumeAnalysisCredit(user.id);
-    if (creditConsumption.response) return creditConsumption.response;
-
     const result = {
       success: true,
       analysisType: "single",
@@ -813,10 +882,25 @@ export async function POST(request: NextRequest) {
       analysisDate: new Date().toISOString(),
       imageIndex: imageIndex || 1,
       totalImages: totalImages || 1,
+    };
+
+    const creditConsumption = await saveAnalysisAndConsumeCredit({
+      userId: user.id,
+      payload: createAnalysisRecordPayload({
+        images: [image],
+        additionalInfo,
+        result,
+      }),
+    });
+    if (creditConsumption.response) return creditConsumption.response;
+
+    const responseBody = {
+      ...result,
+      savedAnalysisId: creditConsumption.analysisId,
       user: creditConsumption.user,
     };
 
-    return NextResponse.json(result);
+    return NextResponse.json(responseBody);
   } catch (error) {
     console.error("Analysis error:", error);
     return NextResponse.json(

--- a/src/app/api/user/analyses/route.ts
+++ b/src/app/api/user/analyses/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "../history/route";

--- a/src/app/api/user/history/route.ts
+++ b/src/app/api/user/history/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
+import { getCurrentUser } from "@/lib/auth";
 
 type AnalysisPayload = Record<string, unknown>;
 
@@ -12,6 +13,41 @@ const getUserFromToken = (token: string) => {
   } catch {
     return null;
   }
+};
+
+const getAuthenticatedUserId = async (request: NextRequest) => {
+  const currentUser = await getCurrentUser();
+
+  if (currentUser) {
+    return currentUser.id;
+  }
+
+  const authHeader = request.headers.get("authorization");
+  const token = authHeader?.replace("Bearer ", "");
+
+  return token ? getUserFromToken(token) : null;
+};
+
+const getNestedObject = (
+  payload: AnalysisPayload,
+  key: string,
+): AnalysisPayload => {
+  const value = payload[key];
+
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as AnalysisPayload)
+    : {};
+};
+
+const getEstimatedCost = (result: AnalysisPayload) => {
+  const pricing = getNestedObject(result, "pricing");
+  const estimatedMeatValue = pricing.estimatedMeatValue;
+
+  if (typeof estimatedMeatValue === "number") {
+    return estimatedMeatValue;
+  }
+
+  return typeof result.marketValue === "number" ? result.marketValue : 0;
 };
 
 const toAnalysisResponse = ({
@@ -29,27 +65,29 @@ const toAnalysisResponse = ({
     payload && typeof payload === "object" && !Array.isArray(payload)
       ? (payload as AnalysisPayload)
       : {};
+  const result = getNestedObject(normalizedPayload, "result");
+  const analysisDate =
+    typeof result.analysisDate === "string" ? result.analysisDate : null;
 
   return {
     ...normalizedPayload,
     id,
     userId,
     createdAt: createdAt.toISOString(),
+    date: analysisDate ?? createdAt.toISOString(),
+    animalType:
+      typeof result.animalType === "string" ? result.animalType : "Bilinmiyor",
+    estimatedWeight:
+      typeof result.estimatedWeight === "number" ? result.estimatedWeight : 0,
+    estimatedCost: getEstimatedCost(result),
   };
 };
 
 export async function GET(request: NextRequest) {
   try {
-    const authHeader = request.headers.get("authorization");
-    const token = authHeader?.replace("Bearer ", "");
-
-    if (!token) {
-      return NextResponse.json({ error: "Token gerekli" }, { status: 401 });
-    }
-
-    const userId = getUserFromToken(token);
+    const userId = await getAuthenticatedUserId(request);
     if (!userId) {
-      return NextResponse.json({ error: "Geçersiz token" }, { status: 401 });
+      return NextResponse.json({ error: "Oturum gerekli" }, { status: 401 });
     }
 
     const userAnalyses = await prisma.analysis.findMany({
@@ -69,16 +107,9 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const authHeader = request.headers.get("authorization");
-    const token = authHeader?.replace("Bearer ", "");
-
-    if (!token) {
-      return NextResponse.json({ error: "Token gerekli" }, { status: 401 });
-    }
-
-    const userId = getUserFromToken(token);
+    const userId = await getAuthenticatedUserId(request);
     if (!userId) {
-      return NextResponse.json({ error: "Geçersiz token" }, { status: 401 });
+      return NextResponse.json({ error: "Oturum gerekli" }, { status: 401 });
     }
 
     const { analysis } = await request.json();

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,4 +1,8 @@
-import type { User as PrismaUser } from "@prisma/client";
+import type {
+  Analysis as PrismaAnalysis,
+  Prisma,
+  User as PrismaUser,
+} from "@prisma/client";
 import prisma from "@/lib/prisma";
 
 export type User = {
@@ -11,6 +15,13 @@ export type User = {
   address: string;
   usagePurpose: string;
   remainingCredits: number;
+  createdAt: string;
+};
+
+export type AnalysisRecord = {
+  id: string;
+  userId: string;
+  payload: Prisma.JsonValue;
   createdAt: string;
 };
 
@@ -33,6 +44,13 @@ const mapUserRecord = (user: PrismaUser): User => ({
   usagePurpose: user.usagePurpose,
   remainingCredits: user.remainingCredits,
   createdAt: user.createdAt.toISOString(),
+});
+
+const mapAnalysisRecord = (analysis: PrismaAnalysis): AnalysisRecord => ({
+  id: analysis.id,
+  userId: analysis.userId,
+  payload: analysis.payload,
+  createdAt: analysis.createdAt.toISOString(),
 });
 
 export const getUserByEmail = async (email: string): Promise<User | null> => {
@@ -112,6 +130,51 @@ export const decrementUserCredit = async (
   });
 
   return updatedUser ? mapUserRecord(updatedUser) : null;
+};
+
+export const decrementUserCreditAndCreateAnalysis = async (
+  userId: string,
+  payload: Prisma.InputJsonObject,
+): Promise<{ user: User; analysis: AnalysisRecord } | null> => {
+  const result = await prisma.$transaction(async (transaction) => {
+    const currentUser = await transaction.user.findUnique({
+      where: { id: userId },
+    });
+
+    if (!currentUser || currentUser.remainingCredits <= 0) {
+      return null;
+    }
+
+    const updatedUser = await transaction.user.update({
+      where: { id: userId },
+      data: {
+        remainingCredits: {
+          decrement: 1,
+        },
+      },
+    });
+
+    const analysis = await transaction.analysis.create({
+      data: {
+        userId,
+        payload,
+      },
+    });
+
+    return {
+      user: updatedUser,
+      analysis,
+    };
+  });
+
+  if (!result) {
+    return null;
+  }
+
+  return {
+    user: mapUserRecord(result.user),
+    analysis: mapAnalysisRecord(result.analysis),
+  };
 };
 
 export const addUserCredits = async (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Persist successful single and multi-photo analysis runs to the existing `analyses` table.
- Store submitted photo data, selected form inputs, analysis output, and metadata in the JSON payload.
- Make user history endpoints read the saved payload with cookie-based auth and expose `/api/user/analyses` for the account page.

### Testing
- `npm run lint` passed.
- `npm run build` passed.
- `DATABASE_URL="mysql://root:root@localhost:3306/kurban_ai" npx prisma validate` passed.
- Production route smoke test passed for auth-protected `/api/user/history`, `/api/user/analyses`, and `/api/analyze` responses.

### Note
- This Cursor Cloud image does not include MySQL or Docker, so a real database insert could not be executed locally; build/type checks and route runtime smoke tests passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7a9e8aa-5053-4064-b32e-ed4a4bf3f829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7a9e8aa-5053-4064-b32e-ed4a4bf3f829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

